### PR TITLE
Initialize MarkBind site config

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           rootDirectory: './docs'
-          baseUrl: '/addressbook-level3' # replace with your repo name
+          baseUrl: '/tp'
           version: '^5.1.0'

--- a/docs/_markbind/layouts/default.md
+++ b/docs/_markbind/layouts/default.md
@@ -4,7 +4,7 @@
 
 <header sticky>
   <navbar type="dark">
-    <a slot="brand" href="{{baseUrl}}/index.html" title="Home" class="navbar-brand">AB-3</a>
+    <a slot="brand" href="{{baseUrl}}/index.html" title="Home" class="navbar-brand">CampusConnect</a>
     <li><a href="{{baseUrl}}/UserGuide.html" class="nav-link">User Guide</a></li>
     <li><a href="{{baseUrl}}/DeveloperGuide.html" class="nav-link">Developer Guide</a></li>
     <li><a href="{{baseUrl}}/AboutUs.html" class="nav-link">About Us</a></li>

--- a/docs/site.json
+++ b/docs/site.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "",
-  "titlePrefix": "",
-  "titleSuffix": "AddressBook Level-3",
+  "titlePrefix": "CampusConnect",
+  "titleSuffix": "",
   "faviconPath": "images/SeEduLogo.png",
   "style": {
     "codeTheme": "light"


### PR DESCRIPTION
As per https://se-education.org/guides/tutorials/markbind-forked-sites.html, initializes MarkBind documentation site with correct defaults and with our product name, CampusConnect

Before:

<img width="1059" alt="image" src="https://github.com/AY2324S1-CS2103T-T13-2/tp/assets/29654756/0c80f4bb-8a86-4383-9a6f-60be561be1f1">

After:

<img width="1342" alt="image" src="https://github.com/AY2324S1-CS2103T-T13-2/tp/assets/29654756/af65c383-229a-425e-9e3d-a9160bcceae6">
