### PR TITLE
Add emergency tags feature

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.Tag;
@@ -106,6 +107,26 @@ public class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns a set of non-emergency tags.
+     * @return
+     */
+    public Set<Tag> getNonEmergencyTags() {
+        return tags.stream()
+            .filter(tag -> !Tag.EmergencyTags.isEmergencyTag(tag.tagName))
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns a set of emergency tags.
+     * @return
+     */
+    public Set<Tag> getEmergencyTags() {
+        return tags.stream()
+            .filter(tag -> Tag.EmergencyTags.isEmergencyTag(tag.tagName))
+            .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -15,6 +15,25 @@ public class Tag {
     public final String tagName;
 
     /**
+     * Enum for emergency tags
+     */
+    public enum EmergencyTags {
+        RA,
+        SOS;
+        /**
+         * Returns true if a given string is a valid emergency tag name.
+         */
+        public static boolean isEmergencyTag(String tagName) {
+            for (EmergencyTags tag : EmergencyTags.values()) {
+                if (tag.name().equals(tagName)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
      * Constructs a {@code Tag}.
      *
      * @param tagName A valid tag name.

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -61,7 +61,14 @@ public class PersonCard extends UiPart<Region> {
         linkedin.setText(person.getLinkedin().map(l -> l.value).orElse(""));
         secondaryEmail.setText(person.getSecondaryEmail().map(e -> e.value).orElse(""));
         telegram.setText(person.getTelegram().map(t -> t.value).orElse(""));
-        person.getTags().stream()
+        person.getEmergencyTags().stream()
+            .sorted(Comparator.comparing(tag -> tag.tagName))
+            .forEach(tag -> {
+                Label label = new Label(tag.tagName);
+                label.setStyle("-fx-background-color: red; -fx-text-fill: white;");
+                tags.getChildren().add(label);
+            });
+        person.getNonEmergencyTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }


### PR DESCRIPTION
This PR fixes #47 by adding special functionality to declare certain tags as "emergency tags' and having them be displayed with different UI as follows.
<img width="224" alt="image" src="https://github.com/AY2324S1-CS2103T-T13-2/tp/assets/18553610/52c3af2a-d28f-47f3-9fab-52f59e121952">
