### PR TITLE
Add test for Find command preamble presence

### DIFF
--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -20,6 +20,16 @@ public class FindCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
+    @Test
+    public void parse_hasPreamble_throwsParseException() {
+        // just preamble
+        assertParseFailure(parser, " hello world",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // preamble with valid args after
+        assertParseFailure(parser, " hello world n/Alice",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
 
     @Test
     public void parse_validOneArg_returnsFindCommand() throws ParseException {
@@ -45,7 +55,6 @@ public class FindCommandParserTest {
         // multiple distinct args with repeated fields
         assertDoesNotThrow(() -> parser.parse(" n/Alice t/colleagues t/friends"));
         assertTrue(parser.parse( " n/Alice t/colleagues t/friends") instanceof FindCommand);
-
     }
 
 }


### PR DESCRIPTION
Closes #53, and gives full test coverage for find command parser.

That said, the predicate-chaining logic should probably eventually be separated into a new class so we can test that more intricately