### PR TITLE
Fix outdated docs

### DIFF
--- a/docs/_markbind/layouts/default.md
+++ b/docs/_markbind/layouts/default.md
@@ -8,7 +8,7 @@
     <li><a href="{{baseUrl}}/UserGuide.html" class="nav-link">User Guide</a></li>
     <li><a href="{{baseUrl}}/DeveloperGuide.html" class="nav-link">Developer Guide</a></li>
     <li><a href="{{baseUrl}}/AboutUs.html" class="nav-link">About Us</a></li>
-    <li><a href="https://github.com/se-edu/addressbook-level3" target="_blank" class="nav-link"><md>:fab-github:</md></a>
+    <li><a href="https://github.com/AY2324S1-CS2103T-T13-2/tp" target="_blank" class="nav-link"><md>:fab-github:</md></a>
     </li>
     <li slot="right">
       <form class="navbar-form">

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,17 +3,17 @@
   title: ""
 ---
 
-# AddressBook Level-3
+# CampusConnect
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![Java CI Status](https://github.com/AY2324S1-CS2103T-T13-2/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2324S1-CS2103T-T13-2/tp/actions/workflows/gradle.yml)
+[![codecov](https://codecov.io/gh/AY2324S1-CS2103T-T13-2/tp/graph/badge.svg?token=V0VMEEZQIF)](https://codecov.io/gh/AY2324S1-CS2103T-T13-2/tp)
 
 ![Ui](images/Ui.png)
 
-**AddressBook is a desktop application for managing your contact details.** While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
+**CampusConnect** is a desktop application built for **NUS students** living on campus to help them **stay organised**, **stay connected**, and **make the on-campus experience at NUS stress-free**. It is **optimised for use** via **Command Line Interface (CLI)** while benefiting from a **Graphical User Interface (GUI)**.
 
-* If you are interested in using AddressBook, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
-* If you are interested about developing AddressBook, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
+* If you are interested in using CampusConnect, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
+* If you are interested about developing CampusConnect, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
 
 
 **Acknowledgements**


### PR DESCRIPTION
There are some remaining artifacts in the documentation that refer to AB3. This PR fixes these:

1. Github link in navbar
2. Index page of documentation
3. CI and codecov widgets