### PR TITLE
Improve parsing for `notes`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -324,11 +324,12 @@ The parameters for these commands are `PERSON_INDEX`, `NOTE_INDEX` and `NOTE_CON
 <br>
 <panel header=":fa-solid-book: **Command Parameter / Syntax Tables**" type="secondary" expanded no-close>
 The fields you enter should follow the following format:
+
 | Parameter     | Description                                                                                                 |
 |---------------|-------------------------------------------------------------------------------------------------------------|
 | `PERSON_INDEX`| The position of the person in the list you want to add a note to. This should be a positive integer, and should be within the bounds of the list. |
 | `NOTE_INDEX`  | The position of the note in the person's list of notes you want to remove. This should be a positive integer, and should be within the bounds of the list. |
-| `NOTE_CONTENT`| The content of the note you want to add. It has to be non-empty, and can contain any character.              |
+| `NOTE_CONTENT`| The content of the note you want to add. It has to be non-empty, surrounded by double quotation marks, and can only contain basic Latin alphabet characters (both uppercase and lowercase), numbers, common punctuation marks, and whitespace. |
 
 </panel>
 
@@ -345,8 +346,8 @@ Format: `addnote PERSON_INDEX NOTE_CONTENT`
 <box type="info" icon=":fa-solid-magnifying-glass:">
 Below are some examples on how to use the commands:
 
-- `addnote 1 This is a sample note for the person.`: Adds a note to the contact at index 1.
-- `addnote 2 This is another sample note.`: Adds a note to the contact at index 2.
+- `addnote 1 "This is a sample note for the person."`: Adds a note to the contact at index 1.
+- `addnote 2 "This is another sample note."`: Adds a note to the contact at index 2.
 
 </box>
 

--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -20,7 +20,7 @@ public class AddNoteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a note to the person "
         + "identified by the index number used in the last person listing. "
         + "Parameters: INDEX (must be a positive integer) NOTE_CONTENT\n"
-        + "Example: " + COMMAND_WORD + " 1 This is a sample note for the person.";
+        + "Example: " + COMMAND_WORD + " 1 \"This is a sample note for the person.\"";
     public static final String MESSAGE_NOTE_SUCCESS = "Added note to person.";
     private final Index index;
     private final Note note;

--- a/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
@@ -23,15 +23,15 @@ public class AddNoteCommandParser implements Parser<AddNoteCommand> {
             String[] splitArgs = args.trim().split("\\s", 2);
 
             if (splitArgs.length < 2) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+                throw new ParseException(AddNoteCommand.MESSAGE_USAGE);
             }
 
             Index index = ParserUtil.parseIndex(splitArgs[0]);
-            Note note = new Note(splitArgs[1].trim());
+            Note note = ParserUtil.parseNote(splitArgs[1].trim());
 
             return new AddNoteCommand(index, note);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage()));
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -202,8 +202,6 @@ public class ParserUtil {
         String content = trimmedNotes.substring(1, trimmedNotes.length() - 1);
 
         // Define the valid characters for notes.
-        // Allowing basic Latin alphabet characters (both uppercase and lowercase), numbers, common punctuation marks, and whitespace.
-
         if (!content.matches(Note.VALIDATION_REGEX)) {
             throw new ParseException(Note.MESSAGE_CONSTRAINTS_INVALID_CHARACTERS);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Linkedin;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Note;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Telegram;
 import seedu.address.model.tag.Tag;
@@ -173,6 +174,41 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+    /**
+     * Parses a {@code String notes} into a {@code Notes}.
+     * The notes should start and end with a double quotation mark (").
+     * Leading and trailing whitespaces outside the quotation marks will be trimmed.
+     *
+     * @param notes The string input to be parsed.
+     * @return A valid Notes object.
+     * @throws ParseException if the given {@code notes} contains invalid characters or does not start and end with ".
+     */
+    public static Note parseNote(String notes) throws ParseException {
+        requireNonNull(notes);
+        String trimmedNotes = notes.trim();
+
+        // Check that the notes start and end with a double quotation mark
+        if (trimmedNotes.length() < 2 || !trimmedNotes.startsWith("\"") || !trimmedNotes.endsWith("\"")) {
+            throw new ParseException(Note.MESSAGE_CONSTRAINTS_START_END_QUOTE);
+        }
+
+        //Don't allow blank notes
+        if (trimmedNotes.length() == 2) {
+            throw new ParseException(Note.MESSAGE_CONSTRAINTS_BLANK);
+        }
+
+        // Remove the starting and ending quotation marks
+        String content = trimmedNotes.substring(1, trimmedNotes.length() - 1);
+
+        // Define the valid characters for notes.
+        // Allowing basic Latin alphabet characters (both uppercase and lowercase), numbers, common punctuation marks, and whitespace.
+
+        if (!content.matches(Note.VALIDATION_REGEX)) {
+            throw new ParseException(Note.MESSAGE_CONSTRAINTS_INVALID_CHARACTERS);
+        }
+
+        return new Note(content);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Note.java
+++ b/src/main/java/seedu/address/model/person/Note.java
@@ -8,11 +8,20 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Represents a Note in the address book.
  */
 public class Note {
-    public static final String MESSAGE_CONSTRAINTS = "Notes can only contain alphanumeric characters, spaces, and common punctuation "
-        + "and it should not be blank";
-    public static final String MESSAGE_CONSTRAINTS_START_END_QUOTE = "Notes must start and end with a double quotation mark (\").";
-    public static final String MESSAGE_CONSTRAINTS_BLANK = "Notes cannot be blank. It must contain at least one valid character.";
-    public static final String MESSAGE_CONSTRAINTS_INVALID_CHARACTERS = "Notes can only contain basic Latin alphabet characters (both uppercase and lowercase), numbers, common punctuation marks, and whitespace.";
+    public static final String MESSAGE_CONSTRAINTS =
+        "Notes can only contain alphanumeric characters, spaces, "
+        + "and common punctuation and it should not be blank.";
+
+    public static final String MESSAGE_CONSTRAINTS_START_END_QUOTE =
+        "Notes must start and end with a double quotation mark (\").";
+
+    public static final String MESSAGE_CONSTRAINTS_BLANK =
+        "Notes cannot be blank. It must contain at least one valid character.";
+
+    public static final String MESSAGE_CONSTRAINTS_INVALID_CHARACTERS =
+        "Notes can only contain basic Latin alphabet characters "
+        + "(both uppercase and lowercase), numbers, common punctuation "
+        + "marks, and whitespace.";
 
     public static final String VALIDATION_REGEX = "([a-zA-Z0-9 ,.!?;:'\"()\\-\\n]*)";
 

--- a/src/main/java/seedu/address/model/person/Note.java
+++ b/src/main/java/seedu/address/model/person/Note.java
@@ -1,29 +1,72 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
 /**
  * Represents a Note in the address book.
  */
 public class Note {
-    private final String text;
+    public static final String MESSAGE_CONSTRAINTS = "Notes can only contain alphanumeric characters, spaces, and common punctuation "
+        + "and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS_START_END_QUOTE = "Notes must start and end with a double quotation mark (\").";
+    public static final String MESSAGE_CONSTRAINTS_BLANK = "Notes cannot be blank. It must contain at least one valid character.";
+    public static final String MESSAGE_CONSTRAINTS_INVALID_CHARACTERS = "Notes can only contain basic Latin alphabet characters (both uppercase and lowercase), numbers, common punctuation marks, and whitespace.";
 
+    public static final String VALIDATION_REGEX = "([a-zA-Z0-9 ,.!?;:'\"()\\-\\n]*)";
+
+    private final String text;
+    /**
+     * Constructs a {@code Note}.
+     */
     public Note() {
         this.text = "";
     }
 
-    public Note(String note) {
-        this.text = note;
+    /**
+     * Constructs a {@code Note}.
+     *
+     * @param text A valid note.
+     */
+    public Note(String text) {
+        requireNonNull(text);
+        this.text = text;
+    }
+
+    /**
+     * Returns true if a given string is a valid note.
+     */
+    public static boolean isValidNote(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Parses a {@code String note} into a {@code Note}.
+     * Leading and trailing whitespaces will be trimmed.
+     * @param note A raw string input of note
+     * @return A valid Note object
+     * @throws ParseException if the given {@code note} is invalid.
+     */
+    public static Note parseNote(String note) throws ParseException {
+        requireNonNull(note);
+        String trimmedNote = note.trim();
+        if (!isValidNote(trimmedNote)) {
+            throw new ParseException(MESSAGE_CONSTRAINTS);
+        }
+        return new Note(trimmedNote);
     }
 
     @Override
     public String toString() {
-        return this.text;
+        return text;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof Note // instanceof handles nulls
-                && text.equals(((Note) other).text)); // state check
+            || (other instanceof Note // instanceof handles nulls
+            && text.equals(((Note) other).text)); // state check
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Note.java
+++ b/src/main/java/seedu/address/model/person/Note.java
@@ -50,22 +50,6 @@ public class Note {
         return test.matches(VALIDATION_REGEX);
     }
 
-    /**
-     * Parses a {@code String note} into a {@code Note}.
-     * Leading and trailing whitespaces will be trimmed.
-     * @param note A raw string input of note
-     * @return A valid Note object
-     * @throws ParseException if the given {@code note} is invalid.
-     */
-    public static Note parseNote(String note) throws ParseException {
-        requireNonNull(note);
-        String trimmedNote = note.trim();
-        if (!isValidNote(trimmedNote)) {
-            throw new ParseException(MESSAGE_CONSTRAINTS);
-        }
-        return new Note(trimmedNote);
-    }
-
     @Override
     public String toString() {
         return text;

--- a/src/main/java/seedu/address/model/person/Note.java
+++ b/src/main/java/seedu/address/model/person/Note.java
@@ -2,8 +2,6 @@ package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.address.logic.parser.exceptions.ParseException;
-
 /**
  * Represents a Note in the address book.
  */

--- a/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,29 +28,29 @@ public class AddNoteCommandParserTest {
 
         // Missing index
         assertParseFailure(parser, "\"Test note\"",
-            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_INDEX));
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid index
         assertParseFailure(parser, "0 \"Test note\"",
-            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_INDEX));
 
         // invalid characters in note
         assertParseFailure(parser, "1 \"Test @note\"",
-            Note.MESSAGE_CONSTRAINTS_INVALID_CHARACTERS);
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, Note.MESSAGE_CONSTRAINTS_INVALID_CHARACTERS));
 
         // missing starting quotation mark
         assertParseFailure(parser, "1 Test note\"",
-            Note.MESSAGE_CONSTRAINTS_START_END_QUOTE);
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, Note.MESSAGE_CONSTRAINTS_START_END_QUOTE));
 
         // missing ending quotation mark
         assertParseFailure(parser, "1 \"Test note",
-            Note.MESSAGE_CONSTRAINTS_START_END_QUOTE);
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, Note.MESSAGE_CONSTRAINTS_START_END_QUOTE));
 
         // blank note
         assertParseFailure(parser, "1 \"\"",
-            Note.MESSAGE_CONSTRAINTS_BLANK);
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, Note.MESSAGE_CONSTRAINTS_BLANK));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,7 @@ public class AddNoteCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         AddNoteCommand expectedCommand = new AddNoteCommand(Index.fromZeroBased(0), new Note("Test note"));
-        assertParseSuccess(parser, "1 Test note", expectedCommand);
+        assertParseSuccess(parser, "1 \"Test note\"", expectedCommand);
     }
 
     @Test
@@ -26,7 +27,30 @@ public class AddNoteCommandParserTest {
             String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
 
         // Missing index
-        assertParseFailure(parser, "Test note",
+        assertParseFailure(parser, "\"Test note\"",
             String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid index
+        assertParseFailure(parser, "0 \"Test note\"",
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+
+        // invalid characters in note
+        assertParseFailure(parser, "1 \"Test @note\"",
+            Note.MESSAGE_CONSTRAINTS_INVALID_CHARACTERS);
+
+        // missing starting quotation mark
+        assertParseFailure(parser, "1 Test note\"",
+            Note.MESSAGE_CONSTRAINTS_START_END_QUOTE);
+
+        // missing ending quotation mark
+        assertParseFailure(parser, "1 \"Test note",
+            Note.MESSAGE_CONSTRAINTS_START_END_QUOTE);
+
+        // blank note
+        assertParseFailure(parser, "1 \"\"",
+            Note.MESSAGE_CONSTRAINTS_BLANK);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -89,7 +89,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_note() throws Exception {
         Note note = new Note("Sample note");
-        assertTrue(parser.parseCommand(AddNoteCommand.COMMAND_WORD + " 1 Sample note") instanceof AddNoteCommand);
+        assertTrue(parser.parseCommand(AddNoteCommand.COMMAND_WORD + " 1 \"Sample note\"") instanceof AddNoteCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NotesTest.java
+++ b/src/test/java/seedu/address/model/person/NotesTest.java
@@ -1,9 +1,11 @@
 package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 
@@ -97,5 +99,25 @@ public class NotesTest {
         assertEquals(2, person.getNotes().size());
         assertEquals(note1, person.getNotes().get(0));
         assertEquals(note2, person.getNotes().get(1));
+    }
+
+    @Test
+    public void isValidNote_validNoteWithAlphabetsAndNumbers_returnsTrue() {
+        assertTrue(Note.isValidNote("A simple note 123"));
+    }
+
+    @Test
+    public void isValidNote_validNoteWithSpecialCharacters_returnsTrue() {
+        assertTrue(Note.isValidNote("A note with special characters !?;:'\"(),.-"));
+    }
+
+    @Test
+    public void isValidNote_validNoteWithNewLines_returnsTrue() {
+        assertTrue(Note.isValidNote("A note with new line\ncharacters"));
+    }
+
+    @Test
+    public void isValidNote_invalidNoteWithExtraSpecialCharacters_returnsFalse() {
+        assertFalse(Note.isValidNote("A note with invalid characters @#{}[]"));
     }
 }


### PR DESCRIPTION
Improves parsing for notes `NOTE_CONTENT`. Now the content of the note you want to add has to be non-empty, surrounded by double quotation marks, and can only contain basic Latin alphabet characters (both uppercase and lowercase), numbers, common punctuation marks, and whitespace.

- `addnote 1 "This is a sample note for the person."`: Adds a note to the contact at index 1.

