### PR TITLE
Fix inaccurate birthday notification behaviour

### DIFF
--- a/src/main/java/seedu/address/model/event/EventFactory.java
+++ b/src/main/java/seedu/address/model/event/EventFactory.java
@@ -42,19 +42,19 @@ public class EventFactory {
                     );
 
             // Birthday has not passed this year
-            if (birthdayThisYear.isAfter(LocalDate.now())) {
+            if (birthdayThisYear.isAfter(LocalDate.now()) || birthdayThisYear.equals(LocalDate.now())) {
                 event = new Event(
                         String.format("%s's Birthday", person.getName()), "",
-                        birthdayThisYear.atTime(0, 0)
+                        birthdayThisYear.atTime(23, 59)
                 );
             } else {
                 event = new Event(
                         String.format("%s's Birthday", person.getName()), "",
-                        birthdayNextYear.atTime(0, 0)
+                        birthdayNextYear.atTime(23, 59)
                 );
             }
 
-            event.addReminder(Duration.ofDays(1)); // Birthday reminder defaults to 1 day in advance
+            event.addReminder(Duration.ofDays(2)); // Birthday reminder within 1 day of the birthday
             event.addMember(person);
             events.add(event);
         }


### PR DESCRIPTION
Our **User Guide** advertises

> Every time you open CampusConnect, a pop-up notification will appear for contacts whose birthdays are **within one day.**

However, our current implementation does not cover the case where the birthday falls on the day the user opens the app (which is within one day). This PR will fix this implementation issue.

This bug was identified during PE-D and labeled as a variety of bug types, it will be fixed as a functionality bug, using the User Guide as the source of truth for feature behaviour.

Closes https://github.com/AY2324S1-CS2103T-T13-2/tp/issues/197
Closes https://github.com/AY2324S1-CS2103T-T13-2/tp/issues/185
Closes https://github.com/AY2324S1-CS2103T-T13-2/tp/issues/177
Closes https://github.com/AY2324S1-CS2103T-T13-2/tp/issues/172
