### PR TITLE
Fix duplicate tag bug, error message specificity issue and standardize messages for `notes` feature

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -76,15 +76,12 @@ public class StringUtil {
      * Will return false for any other non-null string input
      * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
      * @throws NullPointerException if {@code s} is null.
+     * @throws NumberFormatException if {@code s} is not a number.
      */
-    public static boolean isNonZeroUnsignedInteger(String s) {
+    public static boolean isNonZeroUnsignedInteger(String s) throws NumberFormatException {
         requireNonNull(s);
 
-        try {
-            int value = Integer.parseInt(s);
-            return value > 0 && !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
-        } catch (NumberFormatException nfe) {
-            return false;
-        }
+        int value = Integer.parseInt(s);
+        return value > 0 && !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
     }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -12,9 +12,9 @@ import seedu.address.model.person.Person;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid.";
     public static final String MESSAGE_INVALID_NOTE_DISPLAYED_INDEX = "This note index is invalid!";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteCommand.java
@@ -21,7 +21,7 @@ public class AddNoteCommand extends Command {
         + "identified by the index number used in the last person listing. "
         + "Parameters: INDEX (must be a positive integer) NOTE_CONTENT\n"
         + "Example: " + COMMAND_WORD + " 1 This is a sample note for the person.";
-    public static final String MESSAGE_NOTE_SUCCESS = "Added note to person.";
+    public static final String MESSAGE_NOTE_SUCCESS = "Added note to person: %s";
     private final Index index;
     private final Note note;
 
@@ -44,7 +44,7 @@ public class AddNoteCommand extends Command {
         }
         Person p = lastShownList.get(index.getZeroBased());
         p.addNote(note);
-        return new CommandResult(String.format(MESSAGE_NOTE_SUCCESS, Messages.format(p)));
+        return new CommandResult(String.format(MESSAGE_NOTE_SUCCESS, p.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -27,6 +27,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Avatar;
 import seedu.address.model.person.Balance;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
@@ -128,10 +129,11 @@ public class EditCommand extends Command {
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         Optional<Integer> id = personToEdit.getId();
         ObservableList<Note> notes = personToEdit.getNotes();
+        Avatar avatar = personToEdit.getAvatar();
         Balance balance = personToEdit.getBalance();
 
         Person updatedPerson = new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBirthday,
-                updatedLinkedin, updatedSecondaryEmail, updatedTelegram, updatedTags, id, notes, balance);
+                updatedLinkedin, updatedSecondaryEmail, updatedTelegram, updatedTags, id, avatar, notes, balance);
 
         // Records down the alternative contact fields that are initially empty.
         ArrayList<String> emptyAlternativeContactFields = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/parser/AddAltCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAltCommandParser.java
@@ -35,12 +35,7 @@ public class AddAltCommandParser implements Parser<AddAltCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAltCommand.MESSAGE_USAGE));
         }
 
-        try {
-            index = ParserUtil.parseIndex(preamble);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAltCommand.MESSAGE_USAGE));
-        }
-
+        index = ParserUtil.parseIndex(preamble);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_LINKEDIN, PREFIX_SECONDARY_EMAIL,
                 PREFIX_TELEGRAM, PREFIX_BIRTHDAY);
         AddAltPersonDescriptor addAltPersonDescriptor = new AddAltPersonDescriptor();

--- a/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteCommandParser.java
@@ -12,26 +12,33 @@ import seedu.address.model.person.Note;
  */
 public class AddNoteCommandParser implements Parser<AddNoteCommand> {
 
+    public static final String MESSAGE_EMPTY_NOTE = "NOTE_CONTENT cannot be empty!";
+
     /**
      * Parses the given {@code String} of arguments in the context of the NoteCommand
      * and returns a NoteCommand object for execution.
      * @throws ParseException if the user input does not conform to the expected format
      */
     public AddNoteCommand parse(String args) throws ParseException {
-        try {
-            // Split based on space
-            String[] splitArgs = args.trim().split("\\s", 2);
+        // Split based on space
+        String[] splitArgs = args.trim().split("\\s", 2);
 
-            if (splitArgs.length < 2) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
-            }
-
-            Index index = ParserUtil.parseIndex(splitArgs[0]);
-            Note note = new Note(splitArgs[1].trim());
-
-            return new AddNoteCommand(index, note);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE), pe);
+        // Empty args
+        if (splitArgs[0].isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
         }
+
+        // Only 1 arg
+        if (splitArgs.length == 1) {
+            // Assume that user follows command format so first argument by default is index.
+            ParserUtil.parseIndex(splitArgs[0]);
+            // If user keys in valid index, will then subsequently throw exception; notes cannot be whitespace/empty.
+            throw new ParseException(MESSAGE_EMPTY_NOTE);
+        }
+
+        Index index = ParserUtil.parseIndex(splitArgs[0]);
+        Note note = new Note(splitArgs[1]);
+
+        return new AddNoteCommand(index, note);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,13 +15,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
-        }
+        Index index = ParserUtil.parseIndex(args);
+        return new DeleteCommand(index);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -49,12 +49,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
-        try {
-            index = ParserUtil.parseIndex(preamble);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
-        }
-
+        index = ParserUtil.parseIndex(preamble);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                 PREFIX_BIRTHDAY, PREFIX_SECONDARY_EMAIL, PREFIX_TELEGRAM, PREFIX_LINKEDIN);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -176,7 +176,10 @@ public class ParserUtil {
         requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
-            tagSet.add(parseTag(tagName));
+            Tag tagToAdd = parseTag(tagName);
+            if (!tagSet.contains(tagToAdd)) {
+                tagSet.add(tagToAdd);
+            }
         }
         return tagSet;
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,6 +28,7 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_NOT_A_INDEX = "Index should be an integer.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -36,10 +37,15 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
-        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+        try {
+            boolean isValidIndex = StringUtil.isNonZeroUnsignedInteger(trimmedIndex);
+            if (!isValidIndex) {
+                throw new ParseException(MESSAGE_INVALID_INDEX);
+            }
+            return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+        } catch (NumberFormatException e) {
+            throw new ParseException(MESSAGE_NOT_A_INDEX);
         }
-        return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/RemoveNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveNoteCommandParser.java
@@ -17,22 +17,17 @@ public class RemoveNoteCommandParser implements Parser<RemoveNoteCommand> {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public RemoveNoteCommand parse(String args) throws ParseException {
-        try {
-            // Split based on space
-            String[] splitArgs = args.trim().split("\\s");
+        // Split based on space
+        String[] splitArgs = args.trim().split("\\s");
 
-            if (splitArgs.length != 2) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    RemoveNoteCommand.MESSAGE_USAGE));
-            }
-
-            Index indexPerson = ParserUtil.parseIndex(splitArgs[0]);
-            Index indexNote = ParserUtil.parseIndex(splitArgs[1]);
-
-            return new RemoveNoteCommand(indexPerson, indexNote);
-        } catch (ParseException pe) {
+        if (splitArgs.length != 2) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                RemoveNoteCommand.MESSAGE_USAGE), pe);
+                RemoveNoteCommand.MESSAGE_USAGE));
         }
+
+        Index indexPerson = ParserUtil.parseIndex(splitArgs[0]);
+        Index indexNote = ParserUtil.parseIndex(splitArgs[1]);
+
+        return new RemoveNoteCommand(indexPerson, indexNote);
     }
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -26,7 +26,7 @@ public class Tag {
          */
         public static boolean isEmergencyTag(String tagName) {
             for (EmergencyTags tag : EmergencyTags.values()) {
-                if (tag.name().equals(tagName)) {
+                if (tag.name().equals(tagName.toUpperCase())) {
                     return true;
                 }
             }
@@ -64,12 +64,12 @@ public class Tag {
         }
 
         Tag otherTag = (Tag) other;
-        return tagName.equals(otherTag.tagName);
+        return tagName.compareToIgnoreCase(otherTag.tagName) == 0;
     }
 
     @Override
     public int hashCode() {
-        return tagName.hashCode();
+        return tagName.toUpperCase().hashCode();
     }
 
     /**

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -16,12 +16,12 @@ public class StringUtilTest {
     public void isNonZeroUnsignedInteger() {
 
         // EP: empty strings
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("")); // Boundary value
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("  "));
+        assertThrows(NumberFormatException.class, () -> StringUtil.isNonZeroUnsignedInteger("")); // Boundary value
+        assertThrows(NumberFormatException.class, () -> StringUtil.isNonZeroUnsignedInteger("  "));
 
         // EP: not a number
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("a"));
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("aaa"));
+        assertThrows(NumberFormatException.class, () -> StringUtil.isNonZeroUnsignedInteger("a"));
+        assertThrows(NumberFormatException.class, () -> StringUtil.isNonZeroUnsignedInteger("aaa"));
 
         // EP: zero
         assertFalse(StringUtil.isNonZeroUnsignedInteger("0"));
@@ -34,8 +34,10 @@ public class StringUtilTest {
         assertFalse(StringUtil.isNonZeroUnsignedInteger("+1"));
 
         // EP: numbers with white space
-        assertFalse(StringUtil.isNonZeroUnsignedInteger(" 10 ")); // Leading/trailing spaces
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("1 0")); // Spaces in the middle
+        assertThrows(NumberFormatException.class, () ->
+                StringUtil.isNonZeroUnsignedInteger(" 10 ")); // Leading/trailing spaces
+        assertThrows(NumberFormatException.class, () ->
+                StringUtil.isNonZeroUnsignedInteger("1 0")); // Spaces in the middle
 
         // EP: number larger than Integer.MAX_VALUE
         assertFalse(StringUtil.isNonZeroUnsignedInteger(Long.toString(Integer.MAX_VALUE + 1)));

--- a/src/test/java/seedu/address/logic/commands/UpdatePhotoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdatePhotoCommandTest.java
@@ -113,7 +113,7 @@ public class UpdatePhotoCommandTest {
         } catch (ParseException e) {
             fail();
         } catch (CommandException e) {
-            assertEquals(e.getMessage(), "The person index provided is invalid");
+            assertEquals(e.getMessage(), "The person index provided is invalid.");
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddAltCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAltCommandParserTest.java
@@ -86,7 +86,7 @@ public class AddAltCommandParserTest {
         assertParseFailure(parser, "1 b/24/07 b/25/07", Messages.MESSAGE_DUPLICATE_FIELDS + "b/");
 
         // Invalid prefix
-        assertParseFailure(parser, "1 i/string b/24/07", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/string b/24/07", ParserUtil.MESSAGE_NOT_A_INDEX);
     }
 
     @Test
@@ -94,10 +94,10 @@ public class AddAltCommandParserTest {
         // Heuristic: Boundary value analysis
 
         // One value below boundary
-        assertParseFailure(parser, "-1 b/24/07/01" , MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-1 b/24/07/01" , ParserUtil.MESSAGE_INVALID_INDEX);
 
         // Value at boundary
-        assertParseFailure(parser, "0 b/24/07/01" , MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0 b/24/07/01" , ParserUtil.MESSAGE_INVALID_INDEX);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
@@ -22,11 +22,9 @@ public class AddNoteCommandParserTest {
     @Test
     public void parse_missingDetails_failure() {
         // Missing note details
-        assertParseFailure(parser, "1",
-            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1", AddNoteCommandParser.MESSAGE_EMPTY_NOTE);
 
         // Missing index
-        assertParseFailure(parser, "Test note",
-            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "Test note", ParserUtil.MESSAGE_NOT_A_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddNoteCommand;
 import seedu.address.model.person.Note;
 

--- a/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddNoteCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -20,6 +21,10 @@ public class AddNoteCommandParserTest {
 
     @Test
     public void parse_missingDetails_failure() {
+        // No arguments
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddNoteCommand.MESSAGE_USAGE));
+
         // Missing note details
         assertParseFailure(parser, "1", AddNoteCommandParser.MESSAGE_EMPTY_NOTE);
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -27,6 +26,6 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", ParserUtil.MESSAGE_NOT_A_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -80,10 +80,10 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, ParserUtil.MESSAGE_INVALID_INDEX);
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, ParserUtil.MESSAGE_INVALID_INDEX);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/address/logic/parser/OweCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/OweCommandParserTest.java
@@ -24,7 +24,7 @@ class OweCommandParserTest {
     public void parse_invalidArgs_throwsParseException() {
         // Test with invalid index
         assertParseFailure(parser, "a 2.50",
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                ParserUtil.MESSAGE_NOT_A_INDEX);
 
         // Test with invalid negative values
         assertParseFailure(parser, "1 -2.50", Balance.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/parser/PayCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PayCommandParserTest.java
@@ -24,7 +24,7 @@ class PayCommandParserTest {
     public void parse_invalidArgs_throwsParseException() {
         // Test with invalid index
         assertParseFailure(parser, "a 2.50",
-                ParserUtil.MESSAGE_INVALID_INDEX);
+                ParserUtil.MESSAGE_NOT_A_INDEX);
 
         // Test with invalid negative balance
         assertParseFailure(parser, "1 -2.50", Balance.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/parser/RemoveNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemoveNoteCommandParserTest.java
@@ -34,8 +34,7 @@ public class RemoveNoteCommandParserTest {
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveNoteCommand.MESSAGE_USAGE));
 
         // non-numeric characters
-        assertParseFailure(parser, "a b",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveNoteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a b", ParserUtil.MESSAGE_NOT_A_INDEX);
 
         // more than two numbers
         assertParseFailure(parser, "1 2 3",
@@ -53,7 +52,6 @@ public class RemoveNoteCommandParserTest {
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveNoteCommand.MESSAGE_USAGE));
 
         // non-numeric characters
-        assertParseFailure(parser, "a b",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveNoteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a b", ParserUtil.MESSAGE_NOT_A_INDEX);
     }
 }

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -34,6 +35,38 @@ public class TagTest {
         assertFalse(Tag.EmergencyTags.isEmergencyTag("Friend"));
         assertFalse(Tag.EmergencyTags.isEmergencyTag("Buddy"));
         assertFalse(Tag.EmergencyTags.isEmergencyTag(""));
+    }
+
+    @Test
+    public void equals() {
+        Tag tag = new Tag("friends");
+
+        // same values (same case) -> returns true
+        assertTrue(tag.equals(new Tag("friends")));
+
+        // same values (i.e., when string is read, they are the same) -> returns true
+        assertTrue(tag.equals(new Tag("FRIENDS")));
+
+        // same object -> returns true
+        assertTrue(tag.equals(tag));
+
+        // null -> returns false
+        assertFalse(tag.equals(null));
+
+        // different types -> returns false
+        assertFalse(tag.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(tag.equals(new Tag("colleagues")));
+    }
+
+    @Test
+    public void testHashCode() {
+        Tag tag1 = new Tag("friends");
+        Tag tag2 = new Tag("friends");
+        Tag tag3 = new Tag("FRIENDS");
+        assertEquals(tag1.hashCode(), tag2.hashCode());
+        assertEquals(tag1.hashCode(), tag3.hashCode());
     }
 
 }


### PR DESCRIPTION
Closes #145, and addresses the invalid index in #196 for `addalt`, `edit` and `delete` and notes feature. It also fixes a bug that a photo is removed when `edit` command is executed due to the changes made to how photo is rendered for each person.

In addition, closes #181 and closes #193